### PR TITLE
add Open know-how manifest to OSP

### DIFF
--- a/okh-OSP.yml
+++ b/okh-OSP.yml
@@ -56,7 +56,7 @@ project-link: https://github.com/cool-fosh/OSP/                      # At least 
 contact:
   name: Brian Chow                            # text
 #  affiliation: [value]                     # text
-  email:  bchow (at) seas (dot) upenn (dot) edu                            # email address
+  email:  bchow(at)seas(dot)upenn(dot)edu                            # email address
 #  social:
 #    - platform: [value]                    # text
 #      user-handle: [value]                 # text

--- a/okh-OSP.yml
+++ b/okh-OSP.yml
@@ -53,10 +53,10 @@ project-link: https://github.com/cool-fosh/OSP/                      # At least 
 #health-safety-notice: |                    # paragraph
 #  [value]
 
-#contact:
-#  name: [value]                            # text
+contact:
+  name: Brian Chow                            # text
 #  affiliation: [value]                     # text
-#  email: [value]                           # email address
+  email:  bchow (at) seas (dot) upenn (dot) edu                            # email address
 #  social:
 #    - platform: [value]                    # text
 #      user-handle: [value]                 # text

--- a/okh-OSP.yml
+++ b/okh-OSP.yml
@@ -1,0 +1,170 @@
+# Open know-how manifest
+# according to The Open Know-How Manifest Specification Version 1.0
+# for more info, see http://openknowhow.org/
+
+# The content of this manifest file is licensed under a Creative Commons Attribution 4.0 International License.
+# Licenses for modification and distribution of the hardware, documentation, source-code, etc are stated separately.
+
+# Remove any fields that are not used. Comments (beginning with '#') may also be removed.
+
+# Manifest metadata
+
+date-created: 2019-12-01                   # YYYY-MM-DD
+
+#date-updated: [value]                      # YYYY-MM-DD
+
+manifest-author:
+  name: Andre Maia Chagas                  # required | text
+  affiliation: University of Sussex        # text
+  email: a.maia-chagas@sussex.ac.uk        # email address
+
+manifest-language: EN-UK
+
+#documentation-language: [language-code]-[region]
+
+#manifest-is-translation:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+#  lang: [language]-[region]                # language of original
+
+#documentation-is-translation:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+#  lang: [language]-[region]                # language of original
+
+# Properties
+
+title: Open Source Plate Reader                             # required | text | A title to identify the thing
+
+description: |                             # required | paragraph
+  OSP is a low-cost open-source plate reader built out of the [Chow Lab](http://chowlab.seas.upenn.edu/) and the [George H. Stephenson Foundation Bioengineering Educational Laboratory & Bio-MakerSpace](https://belabs.seas.upenn.edu/) at the University of Pennsylvania. The software provided in this repository is required to access the full functionailty of a built OSP device. For information regarding how to build this device and details about how it works, please refer to the ACS: BioChemistry manuscript available at this [LINK](https://www.biorxiv.org/content/early/2018/09/12/413781)
+
+#intended-use: |                            # recommended | Paragraph
+#  [value]
+
+keywords:                                  # At least one keyword is recommended | text array
+  - Plate Reader
+  - Molecular Biology
+
+project-link: https://github.com/brianchowlab/OSP                      # At least project-link or documentation-home is required, otherwise recommended | absolute path URL
+
+#health-safety-notice: |                    # paragraph
+#  [value]
+
+#contact:
+#  name: [value]                            # text
+#  affiliation: [value]                     # text
+#  email: [value]                           # email address
+#  social:
+#    - platform: [value]                    # text
+#      user-handle: [value]                 # text
+
+contributors:                              # recommended
+  - name: brianchowlab                  # text
+#    affiliation: [value]                   # text
+#    email: [value]                         # email address
+
+#image: [value]                             # recommended | absolute or relative path
+
+#version: [value]                           # text
+
+#development-stage: [value]                 # text
+
+#made: [true/false]                         # boolean - true or false
+
+#made-independently: [true/false]           # boolean - true or false
+
+#standards-used:
+#  - standard-title: [value]                # Required where used | Title of the standard used in developing the design or documentation
+#    publisher: [value]                     # Publisher of the standard
+#    reference: [value]                     # Reference indentifier of the standard (e.g. ISO 9001)
+#    certification:                         # If certification has been granted confirming compliance with the standard
+#      - certifier: [value]                 # Individual or organisation granting the certification. Use "Self" for self-certification
+#        date-awarded: [value]              # Date certification was granted
+#        link: [value]                      # Link to evidence of certification (e.g. certificate). Use an an absolute path to an external resource or an absolute or relative path to evidence within the documentation.
+
+#derivative-of:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+
+#variant-of:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+
+#sub:
+#  title: [sub 1]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+
+# License
+
+license:                                   # At least one license is required | The format should be an SPDX identifier. See https://spdx.org/licenses/hardware: [value] # recommended | The license under which the hardware is released
+  #hardware: [value]                        # recommended | The license under which the documentation is released
+  documentation: CC-BY-SA 4.0 #based on the pre print license   # recommended | The license under which the documentation is released
+  #software: [value]                        # recommended where software is used | The license under which the software is released
+
+#licensor:
+#  name: [value]                            # text
+#  affiliation: [value]                     # text
+#  email: [value]                           # email address
+
+# Documentation
+
+documentation-home: [value]               # At least one of the project-link or documentation-home fields is required | absolute path
+
+#archive-download: [value]                 # Absolute or relative path
+
+#design-files:                             # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#schematics:                               # recommended where applicable
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#bom: [value]                              # recommended | absolute or relative path | Direct the maker to the Bill of Materials
+
+#tool-list: [value]                        # recommended | absolute or relative path | Direct the maker to a list of tools required to make the thing
+
+#making-instructions:                      # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#manufacturing-files:                      # recommended where applicable
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#risk-assessment:                          # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#tool-settings:                            # recommended where applicable
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#quality-instructions:
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#operating-instructions:                   # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#maintenance-instructions: [value]         # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#disposal-instructions: [value]            # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#software:                                 # recommended where applicable | Source code or executable software that the thing uses
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+# User defined Fields
+# Include any custom / extended fields here

--- a/okh-OSP.yml
+++ b/okh-OSP.yml
@@ -48,7 +48,7 @@ keywords:                                  # At least one keyword is recommended
   - Plate Reader
   - Molecular Biology
 
-project-link: https://github.com/brianchowlab/OSP                      # At least project-link or documentation-home is required, otherwise recommended | absolute path URL
+project-link: https://github.com/cool-fosh/OSP/                      # At least project-link or documentation-home is required, otherwise recommended | absolute path URL
 
 #health-safety-notice: |                    # paragraph
 #  [value]
@@ -66,7 +66,7 @@ contributors:                              # recommended
 #    affiliation: [value]                   # text
 #    email: [value]                         # email address
 
-#image: [value]                             # recommended | absolute or relative path
+image: https://raw.githubusercontent.com/brianchowlab/OSP/master/Software/Graphical%20Files/repoImage.png                             # recommended | absolute or relative path
 
 #version: [value]                           # text
 
@@ -114,7 +114,7 @@ license:                                   # At least one license is required | 
 
 # Documentation
 
-documentation-home: [value]               # At least one of the project-link or documentation-home fields is required | absolute path
+documentation-home: https://github.com/brianchowlab/OSP              # At least one of the project-link or documentation-home fields is required | absolute path
 
 #archive-download: [value]                 # Absolute or relative path
 


### PR DESCRIPTION
Hi!

My name is [Andre](amchagas.github.io), I work at the University of Sussex as a Research Bioengineer developing Open source tools for research and education. I'm currently working with a group of people to make hardware easy to discover.

Named [Open Know How](https://openknowhow.org/) we've come up with a system where a simple file with metadata about a certain project would live in the project documentation page.

From there we are working to create a web-crawler that is going to find these files and index them (the ultimate goal would be to have something like a "hardware" tab on google search (as other search engines).

I took the liberty of creating one of these files for your project, with the bare minimum for it to be indexed in the future! I hope you don't mind! (it is just this .yml file that should live in the root of the repository). 

I created this, because I think this is a useful project and it would be great to have it listed on the Open Know-how repository, so that it would be even easier for other people to find it! I hope you don't mind!

You can find more technical information about Open Know How [here](https://app.standardsrepo.com/MakerNetAlliance/OpenKnowHow/wiki)